### PR TITLE
Updating lua-openssl to the master branch [OPENTOK-39286]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7
+
+RUN yum install -y epel-release && yum update -y
+RUN yum install -y git make gcc libtool zlib-devel openssl-devel patch vim-common
+
+WORKDIR /opt/logd
+VOLUME /opt/logd/bin
+
+COPY . /opt/logd
+
+RUN ./configure --enable-build-luajit --enable-build-openssl --enable-build-libuv && make && make install
+
+CMD /opt/logd/bin/logd


### PR DESCRIPTION
**Commit Hash**
568da3ac51f9eeac33019fd3ae0d58d66b47142d

**What is the purpose of this pull request?**
This is a fix for updating the lua-openssl (one of the submodules) to point it to its master branch rather than a different commit hash, so that the updated TLS methods can be used.

**Any files added/updated?**
Added a new Dockerfile. Updating the submodule would change/add files in it as well.